### PR TITLE
Add script to create liquid html for markdown reviews

### DIFF
--- a/assets/html/reviews/2022-07-24_boogie.html
+++ b/assets/html/reviews/2022-07-24_boogie.html
@@ -3,9 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-MORE_BLACK_SUPERHEROES-WESTSIDE_BOOGIE" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-MORE_BLACK_SUPERHEROES-WESTSIDE_BOOGIE" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}
-
-

--- a/assets/html/reviews/2022-07-24_dnwmibiy.html
+++ b/assets/html/reviews/2022-07-24_dnwmibiy.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-dnwmibiy-Big_Thief" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-dnwmibiy-Big_Thief" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-07-24_jxf.html
+++ b/assets/html/reviews/2022-07-24_jxf.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Good_and_Green_Again-Jake_Xerxes_Fussell" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Good_and_Green_Again-Jake_Xerxes_Fussell" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-07-24_saba.html
+++ b/assets/html/reviews/2022-07-24_saba.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "ZM-Few_Good_Things-Saba" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "ZM-Few_Good_Things-Saba" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-07-24_yaya-bey.html
+++ b/assets/html/reviews/2022-07-24_yaya-bey.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Remember_Your_North_Star-Yaya_Bey" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Remember_Your_North_Star-Yaya_Bey" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-08-31_cheat-codes.html
+++ b/assets/html/reviews/2022-08-31_cheat-codes.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "RT-Cheat_Codes-Black_Thought" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "RT-Cheat_Codes-Black_Thought" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-08-31_florist.html
+++ b/assets/html/reviews/2022-08-31_florist.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Florist-Florist" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Florist-Florist" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-08-31_jid.html
+++ b/assets/html/reviews/2022-08-31_jid.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-The_Forever_Story-JID" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-The_Forever_Story-JID" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-08-31_porridge-radio.html
+++ b/assets/html/reviews/2022-08-31_porridge-radio.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-WSDBLTTS-Porridge_Radio" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-WSDBLTTS-Porridge_Radio" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-09-30_alex-g.html
+++ b/assets/html/reviews/2022-09-30_alex-g.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-alex_g" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-alex_g" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-09-30_jaimie-branch.html
+++ b/assets/html/reviews/2022-09-30_jaimie-branch.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-jaimie_branch" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-jaimie_branch" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-09-30_nilufer-yanya.html
+++ b/assets/html/reviews/2022-09-30_nilufer-yanya.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Nilüfer_Yanya" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Nilüfer_Yanya" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-09-30_trousdale.html
+++ b/assets/html/reviews/2022-09-30_trousdale.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "NA-Trousdale" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "NA-Trousdale" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-11-17_mavi.html
+++ b/assets/html/reviews/2022-11-17_mavi.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Mavi" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Mavi" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-11-17_pip-millet.html
+++ b/assets/html/reviews/2022-11-17_pip-millet.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "ZM-When_Everything_is_Better-Pip_Millet" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "ZM-When_Everything_is_Better-Pip_Millet" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-11-17_plains.html
+++ b/assets/html/reviews/2022-11-17_plains.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-I_Walked_With_You_A_Ways-Plains" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-I_Walked_With_You_A_Ways-Plains" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2022-11-17_sault.html
+++ b/assets/html/reviews/2022-11-17_sault.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Angel-SAULT" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Angel-SAULT" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2023-01-27_dijon.html
+++ b/assets/html/reviews/2023-01-27_dijon.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-Absolutely-Dijon" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-Absolutely-Dijon" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2023-01-27_petey.html
+++ b/assets/html/reviews/2023-01-27_petey.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "Lean_Into_Life-Petey" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "PV-Lean_Into_Life-Petey" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/assets/html/reviews/2023-01-27_rap-ferriera.html
+++ b/assets/html/reviews/2023-01-27_rap-ferriera.html
@@ -3,7 +3,7 @@ layout:
 ---
 
 {% for review in site.reviews %}
-	{% if review.unique_name == "MK-5_to_the_eye_with_stars-RAP_Ferreira" %}
-		{% include review_block.html review=review %}
-	{% endif %}
+    {% if review.unique_name == "MK-5_to_the_eye_with_stars-RAP_Ferreira" %}
+        {% include review_block.html review=review %}
+    {% endif %}
 {% endfor %}

--- a/scripts/create_review_html_files.py
+++ b/scripts/create_review_html_files.py
@@ -1,0 +1,51 @@
+"""
+This script creates a liquid html file in assets/html/reviews for
+each markdown review file.  This is used to enable the randomize
+feature.
+
+REVIEWS_DIR and LIQUID_OUTPUT_DIR are variables which much be set.
+"""
+import os
+from pathlib import Path
+
+def get_review_unique_name(review_file: str):
+    """Extract and return the 'unique_name' from yaml frontmatter of
+    review file."""
+    with open(review_file, 'r') as f:
+        for line in f:
+            if line.startswith('unique_name'):
+                return line.split(': ')[1].strip('\n')
+
+def get_liquid_html(review_unique_name: str) -> None:
+    """Insert the review_name string into the liquid template (update
+    template here)."""
+    return """\
+---
+layout:
+---
+
+{% for review in site.reviews %}
+    {% if review.unique_name == "REPLACE_ME" %}
+        {% include review_block.html review=review %}
+    {% endif %}
+{% endfor %}
+""".replace("REPLACE_ME", review_unique_name)
+
+def main(reviews_dir: str, liquid_output_dir: str):
+    reviews_dir = Path(reviews_dir)
+    liquid_output_dir = Path(liquid_output_dir)
+    review_files = [reviews_dir / review for review in os.listdir(reviews_dir)]
+
+    for review_file in review_files:
+        review_unique_name = get_review_unique_name(review_file)
+        liquid_filename = review_file.stem + '.html'
+        liquid = get_liquid_html(review_unique_name)
+
+        with open(liquid_output_dir / liquid_filename, 'w') as f:
+            f.write(liquid)
+
+if __name__ == '__main__':
+    LIQUID_OUTPUT_DIR = "../assets/html/reviews"
+    REVIEWS_DIR = "../_reviews"
+
+    main(REVIEWS_DIR, LIQUID_OUTPUT_DIR)


### PR DESCRIPTION
Improves on the current process of manually creating a corresponding file in `assets/html/reviews` for each review file by creating all the corresponding review liquid template files in one go. Also useful in case the formatting of the liquid templates ever changes, as they can be easily recreated in new format.